### PR TITLE
added coloring configuration for choropleths

### DIFF
--- a/src/guitares/pyqt5/mapbox/choropleth_layer.py
+++ b/src/guitares/pyqt5/mapbox/choropleth_layer.py
@@ -20,7 +20,7 @@ class ChoroplethLayer(Layer):
             # Read geodataframe from shape file
             data = read_dataframe(data)
 
-        self.gdf = data
+        self.data = data
         self.visible = True
 
         if not self.big_data:
@@ -30,7 +30,7 @@ class ChoroplethLayer(Layer):
                 "addLayer",
                 arglist=[
                     self.map_id,
-                    self.gdf,
+                    self.data,
                     self.min_zoom,
                     self.hover_property,
                     self.color_property,
@@ -38,21 +38,23 @@ class ChoroplethLayer(Layer):
                     self.line_width,
                     self.line_opacity,
                     self.fill_opacity,
-                    self.scaler,
                     self.legend_title,
                     self.unit,
                     self.legend_position,
                     self.side,
-                    self.color_type,
+                    self.color_no,
+                    self.bins,
+                    self.colors,
+                    self.color_labels,
                 ],
             )
         else:
             self.update()
 
     def update(self):
-        if self.gdf is None:
+        if self.data is None:
             return
-        if len(self.gdf) == 0:
+        if len(self.data) == 0:
             # Empty GeoDataFrame
             return
         # Only need to update this layer if it use big data and is visible
@@ -65,7 +67,7 @@ class ChoroplethLayer(Layer):
                 yl0 = coords[0][1]
                 yl1 = coords[1][1]
                 # Limits WGS 84
-                gdf = self.gdf.cx[xl0:xl1, yl0:yl1]
+                gdf = self.data.cx[xl0:xl1, yl0:yl1]
                 # Remove existing layer
                 # Add new layer
                 self.mapbox.runjs(
@@ -81,12 +83,14 @@ class ChoroplethLayer(Layer):
                         self.line_width,
                         self.line_opacity,
                         self.fill_opacity,
-                        self.scaler,
                         self.legend_title,
                         self.unit,
                         self.legend_position,
                         self.side,
-                        self.color_type,
+                        self.color_no,
+                        self.bins,
+                        self.colors,
+                        self.color_labels,
                     ],
                 )
             else:
@@ -127,7 +131,7 @@ class ChoroplethLayer(Layer):
         )
 
     def redraw(self):
-        if isinstance(self.gdf, GeoDataFrame):
-            self.set_data(self.gdf)
+        if isinstance(self.data, GeoDataFrame):
+            self.set_data(self.data)
         if not self.get_visibility():
             self.hide()

--- a/src/guitares/pyqt5/mapbox/layer.py
+++ b/src/guitares/pyqt5/mapbox/layer.py
@@ -265,10 +265,13 @@ class Layer:
             # Make a list of all layers
             layers = list_layers(self.layer)
             for layer in layers:
-                layer.set_visibility(true_or_false)
+                if true_or_false:
+                    layer.show()
+                else:
+                    layer.hide()
         else:
             # Data layer
-            if true_or_false and self.visible:
+            if true_or_false:
                 self.mapbox.runjs(self.main_js, "showLayer", arglist=[self.map_id, self.side])
             else:
                 self.mapbox.runjs(self.main_js, "hideLayer", arglist=[self.map_id, self.side])

--- a/src/guitares/pyqt5/mapbox/server/js/choropleth_layer.js
+++ b/src/guitares/pyqt5/mapbox/server/js/choropleth_layer.js
@@ -8,12 +8,14 @@ export function addLayer(
   lineWidth,
   lineOpacity,
   fillOpacity,
-  scaler,
   legend_title,
   unit,
   legend_position,
   side,
-  color_type,
+  color_no,
+  bins,
+  colors,
+  color_labels,
   ) {
 
   var mp = getMap(side);
@@ -42,7 +44,7 @@ export function addLayer(
     promoteId: hover_property
   });
  
-  if (color_type == 'damage') {
+  if (color_no == 6) {
     mp.addLayer({
       'id': fillId,
       'type': 'fill',
@@ -53,22 +55,22 @@ export function addLayer(
         'step',
         ['get', color_property],
         // This should all not be hard0-coded and provided with input
-        '#FFFFFF',
-        0.000001*scaler,
-        '#FEE9CE',
-        0.06*scaler,
-        '#FDBB84',
-        0.2*scaler,
-        '#FC844E',
-        0.4*scaler,
-        '#E03720',
-        1*scaler,
-        '#860000',
+        colors[0],
+        bins[0],
+        colors[1],
+        bins[1],
+        colors[2],
+        bins[2],
+        colors[3],
+        bins[3],
+        colors[4],
+        bins[4],
+        colors[5],
       ],
       'fill-opacity': fillOpacity
       }
     });
-  } else if (color_type == 'flooding') {
+  } else if (color_no == 4) {
     mp.addLayer({
       'id': fillId,
       'type': 'fill',
@@ -79,13 +81,13 @@ export function addLayer(
         'step',
         ['get', color_property],
         // This should all not be hard0-coded and provided with input
-        '#BED2FF',
-        1 * scaler,
-        '#B4D79E',
-        3 * scaler,
-        '#1F80B8',
-        5 * scaler,
-        '#081D58',
+        colors[0],
+        bins[0],
+        colors[1],
+        bins[1],
+        colors[2],
+        bins[2],
+        colors[3],
       ],
       'fill-opacity': fillOpacity
       }
@@ -111,21 +113,21 @@ export function addLayer(
   });
 
   // Legend
-  if (color_type == 'damage') {
+  if (color_no == 6) {
     var legendItems = [
-      { style: '#FFFFFF', label: '0 '},
-      { style: '#FEE9CE', label: unit + '0 - ' + unit + numberWithCommas(0.06*scaler)},
-      { style: '#FDBB84', label: unit + numberWithCommas(0.06*scaler) + ' - ' + unit + numberWithCommas(0.2*scaler)},
-      { style: '#FC844E', label: unit + numberWithCommas(0.2*scaler) + ' - ' + unit + numberWithCommas(0.4*scaler)},
-      { style: '#E03720', label: unit + numberWithCommas(0.4*scaler) + ' - ' + unit + numberWithCommas(1*scaler)},
-      { style: '#860000', label: '> ' + unit + numberWithCommas(1*scaler)},
+      { style: colors[0], label: color_labels[0]},
+      { style: colors[1], label: color_labels[1]},
+      { style: colors[2], label: color_labels[2]},
+      { style: colors[3], label: color_labels[3]},
+      { style: colors[4], label: color_labels[4]},
+      { style: colors[5], label: color_labels[5]},
     ];
-  } else if (color_type == 'flooding') {
+  } else if (color_no == 4) {
     var legendItems = [
-      { style: '#081D58', label: '> ' + numberWithCommas(5*scaler)},
-      { style: '#1F80B8', label: numberWithCommas(3*scaler) + ' - ' + numberWithCommas(5*scaler)},
-      { style: '#B4D79E', label: numberWithCommas(1*scaler) + ' - ' + numberWithCommas(3*scaler)},
-      { style: '#BED2FF', label: '< ' + numberWithCommas(1*scaler)},
+      { style: colors[0], label: color_labels[0]},
+      { style: colors[1], label: color_labels[1]},
+      { style: colors[2], label: color_labels[2]},
+      { style: colors[3], label: color_labels[3]},
     ];
   }
 


### PR DESCRIPTION
I changed the way the choropleth is created by adding the bins, colors and legend labels as inputs, in order to have fexibility when creating the layer. It is still a bit ugly, because it uses either 4 or 6 bins as input. 
I am not sure how to directly include that as an option in the "paint" option that creates the color mapping. @maartenvanormondt  any ideas on this?

I did some small additional changes in the layer visibility, so please check