### PR TITLE
also add data to self.gdf when adding feature to draw_layer

### DIFF
--- a/src/guitares/pyqt5/mapbox/draw_layer.py
+++ b/src/guitares/pyqt5/mapbox/draw_layer.py
@@ -141,6 +141,7 @@ class DrawLayer(Layer):
             return
         for index, row in gdf.to_crs(4326).iterrows():
             gdf = gpd.GeoDataFrame(geometry=[row["geometry"]], crs=4326)
+            self.gdf = self.gdf.append(gdf, ignore_index=True)
             self.mapbox.runjs("./js/draw_layer.js", "addFeature", arglist=[gdf, self.map_id])
 
     def add_rectangle(self, x0, y0, lenx, leny, rotation):


### PR DESCRIPTION
When using add_rectangle the geodataframe doesn't end up in self.gdf, which is needed if you would like to check for its presence somewhere else in the code.

This addition should add it to self.gdf.