### PR TITLE
Fix set visibility

### DIFF
--- a/src/guitares/pyqt5/mapbox/layer.py
+++ b/src/guitares/pyqt5/mapbox/layer.py
@@ -294,7 +294,10 @@ class Layer:
         if self.layer:
             # Container layer
             for name in self.layer:
-                self.layer[name].set_visibility(true_or_false)
+                if true_or_false:
+                    self.layer[name].show()
+                else:
+                    self.layer[name].hide()
         else:
             # Data layer
             if true_or_false:


### PR DESCRIPTION
Showing or hiding a layer only showed and hided them in the mapbox part. The member of the element class itself was nog fixed for underlaying layers