### PR TITLE
Image layer fixes

### DIFF
--- a/src/guitares/__init__.py
+++ b/src/guitares/__init__.py
@@ -5,4 +5,4 @@ Created on Sun Apr 25 10:58:08 2021
 @author: ormondt
 """
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"

--- a/src/guitares/colormap.py
+++ b/src/guitares/colormap.py
@@ -33,6 +33,8 @@ def cm2png(cmap,
            vmax=1.0,
            legend_title="",
            legend_label="",
+           label_size=8,
+           tick_size=6,
            units="",
            unit_string="",
            decimals=-1,
@@ -55,8 +57,8 @@ def cm2png(cmap,
                                    norm=norm,
                                    orientation=orientation,
                                    label=legend_label)
-    cb.ax.tick_params(labelsize=6)
-
+    cb.ax.tick_params(labelsize=tick_size)
+    cb.set_label(legend_label, size=label_size)
     # Save figure
     fig.savefig(file_name, dpi=150, bbox_inches='tight')
     plt.close(fig)

--- a/src/guitares/map/image_layer.py
+++ b/src/guitares/map/image_layer.py
@@ -11,8 +11,8 @@ import shutil
 from .layer import Layer
 
 class ImageLayer(Layer):
-    def __init__(self, map, id, map_id):
-        super().__init__(map, id, map_id)
+    def __init__(self, map, id, map_id, **kwargs):
+        super().__init__(map, id, map_id, **kwargs)
         self.active = False
         self.type   = "image"
         self.file_name = map_id + ".png"
@@ -52,8 +52,8 @@ class ImageLayer(Layer):
             #     xlim[0] -= 360.0
             bounds = [[xlim[0], xlim[1]], [ylim[0], ylim[1]]]
             overlay_file = f"./overlays/{self.file_name}"
-            self.map.runjs("/js/image_layer.js", "updateLayer", arglist=[overlay_file, self.map_id, bounds])
-            self.map.runjs("/js/image_layer.js", "setOpacity", arglist=[self.map_id, 1.0])
+            self.map.runjs("/js/image_layer.js", "updateLayer", arglist=[overlay_file, self.map_id, bounds, "", self.side])
+            self.map.runjs("/js/image_layer.js", "setOpacity", arglist=[self.map_id, 1.0, self.side])
 
     def set_data(self, data, image_file=None, xlim=None, ylim=None):
 
@@ -70,8 +70,8 @@ class ImageLayer(Layer):
 
         bounds = [[xlim[0], xlim[1]], [ylim[0], ylim[1]]]
         overlay_file = f"./overlays/{self.file_name}"
-        self.map.runjs("/js/image_layer.js", "addLayer", arglist=[self.map_id])
-        self.map.runjs("/js/image_layer.js", "updateLayer", arglist=[overlay_file, self.map_id, bounds])
+        self.map.runjs("/js/image_layer.js", "addLayer", arglist=[self.map_id, self.side])
+        self.map.runjs("/js/image_layer.js", "updateLayer", arglist=[overlay_file, self.map_id, bounds, "", self.side])
 
     # def set_data(self,
     #              data,

--- a/src/guitares/map/image_layer.py
+++ b/src/guitares/map/image_layer.py
@@ -1,14 +1,9 @@
+import glob
 import os
-import time
-
-import rasterio
-import rasterio.features
-from rasterio.warp import calculate_default_transform, reproject, Resampling, transform_bounds
-from rasterio import MemoryFile
-from rasterio.transform import Affine
-import shutil
-
+import numpy as np
+from guitares.colormap import cm2png
 from .layer import Layer
+from .colorbar import ColorBar
 
 class ImageLayer(Layer):
     def __init__(self, map, id, map_id, **kwargs):
@@ -52,10 +47,10 @@ class ImageLayer(Layer):
             #     xlim[0] -= 360.0
             bounds = [[xlim[0], xlim[1]], [ylim[0], ylim[1]]]
             overlay_file = f"./overlays/{self.file_name}"
-            self.map.runjs("/js/image_layer.js", "updateLayer", arglist=[overlay_file, self.map_id, bounds, "", self.side])
+            self.map.runjs("/js/image_layer.js", "updateLayer", arglist=[overlay_file, self.map_id, bounds, self.colorbar, self.side])
             self.map.runjs("/js/image_layer.js", "setOpacity", arglist=[self.map_id, 1.0, self.side])
 
-    def set_data(self, data, image_file=None, xlim=None, ylim=None):
+    def set_data(self, data, image_file=None, xlim=None, ylim=None, colorbar=False):
 
         self.data = data
         self.map.runjs("/js/main.js", "removeLayer", arglist=[self.map_id])
@@ -68,11 +63,54 @@ class ImageLayer(Layer):
             print(f"Something went wrong with map overlay: {self.map_id}, {e}")
             return
 
+        if colorbar and self.side != "b":
+            self.colorbar = self.make_colorbar()
+        else:
+            self.colorbar = ""
+        
         bounds = [[xlim[0], xlim[1]], [ylim[0], ylim[1]]]
         overlay_file = f"./overlays/{self.file_name}"
         self.map.runjs("/js/image_layer.js", "addLayer", arglist=[self.map_id, self.side])
-        self.map.runjs("/js/image_layer.js", "updateLayer", arglist=[overlay_file, self.map_id, bounds, "", self.side])
+        self.map.runjs("/js/image_layer.js", "updateLayer", arglist=[overlay_file, self.map_id, bounds, self.colorbar, self.side])
+        self.map.runjs("/js/image_layer.js", "setOpacity", arglist=[self.map_id, self.opacity, self.side])
+        if self.side != "b":
+            self.map.runjs("/js/image_layer.js", "setLegendPosition", arglist=[self.map_id, self.legend_position, self.side])
+    
+    def make_colorbar(self,):
+        if self.color_values:
+            clrbar = ColorBar(color_values=self.color_values, legend_title=self.legend_title)
+            clrbar.make(0.0, 0.0, decimals=self.decimals)
+            clrbar_dict = clrbar.to_dict()
+        else:
+            # Make colorbar image and send url to js
+            # Delete old legend files
+            for file_name in glob.glob(os.path.join(self.map.server_path, "overlays", self.map_id + ".legend.*.png")):
+                try:
+                    os.remove(file_name)
+                except:
+                    pass
 
+            # add random integer string to legend file to force reload                
+            # create string with random integer between 1 and 1,000,000
+            rstring = str(np.random.randint(1, 1000000))
+            legend_file = self.map_id + ".legend." + rstring + ".png"
+            cm2png(self.data.cmap,
+                file_name = os.path.join(self.map.server_path, "overlays", legend_file),
+                orientation="vertical",
+                vmin=self.data.cmin,
+                vmax=self.data.cmax,
+                legend_title=self.legend_title,
+                legend_label=self.legend_label,
+                label_size=7,
+                tick_size=5,
+                units=self.legend_units,
+                decimals=self.legend_decimals,
+                width=0.5,
+                height=1)
+
+            clrbar_dict = "./overlays/" + legend_file
+        return clrbar_dict
+    
     # def set_data(self,
     #              data,
     #              image_file=None,

--- a/src/guitares/map/image_layer.py
+++ b/src/guitares/map/image_layer.py
@@ -11,7 +11,10 @@ class ImageLayer(Layer):
         self.active = False
         self.type   = "image"
         self.file_name = map_id + ".png"
-
+        self.colorbar = None
+        self.xlim = None
+        self.ylim = None
+        
     def activate(self):
         self.active = True
         self.show()
@@ -25,7 +28,15 @@ class ImageLayer(Layer):
         # self.map.view.page().runJavaScript(js_string)
         self.map.runjs("/js/main.js", "removeLayer", arglist=[self.map_id])
 
-
+    def show(self):
+        self.visible = True # to make sure update is run
+        coords = self.map.map_extent
+        xlim = [coords[0][0], coords[1][0]]
+        ylim = [coords[0][1], coords[1][1]]
+        if not (xlim == self.xlim and ylim == self.ylim):
+            self.update() # Update the layer if the extent has changed
+        super().show()  # Call the parent class method
+    
     def make_overlay(self):    
         fname = os.path.join(self.map.server_path, "overlays", self.file_name)
         coords = self.map.map_extent
@@ -34,12 +45,14 @@ class ImageLayer(Layer):
         width = self.map.view.geometry().width()
         okay = self.data.map_overlay(fname, xlim=xlim, ylim=ylim, width=width)
         if okay:
+            self.xlim = xlim
+            self.ylim = ylim
             return xlim, ylim
         else:
             return None, None
 
     def update(self):
-        if hasattr(self.data, "map_overlay"):
+        if hasattr(self.data, "map_overlay") and self.visible:
             xlim, ylim = self.make_overlay()
             if xlim is None:
                 return
@@ -48,7 +61,7 @@ class ImageLayer(Layer):
             bounds = [[xlim[0], xlim[1]], [ylim[0], ylim[1]]]
             overlay_file = f"./overlays/{self.file_name}"
             self.map.runjs("/js/image_layer.js", "updateLayer", arglist=[overlay_file, self.map_id, bounds, self.colorbar, self.side])
-            self.map.runjs("/js/image_layer.js", "setOpacity", arglist=[self.map_id, 1.0, self.side])
+            self.map.runjs("/js/image_layer.js", "setOpacity", arglist=[self.map_id, self.opacity, self.side])
 
     def set_data(self, data, image_file=None, xlim=None, ylim=None, colorbar=False):
 
@@ -70,8 +83,7 @@ class ImageLayer(Layer):
         
         bounds = [[xlim[0], xlim[1]], [ylim[0], ylim[1]]]
         overlay_file = f"./overlays/{self.file_name}"
-        self.map.runjs("/js/image_layer.js", "addLayer", arglist=[self.map_id, self.side])
-        self.map.runjs("/js/image_layer.js", "updateLayer", arglist=[overlay_file, self.map_id, bounds, self.colorbar, self.side])
+        self.map.runjs("/js/image_layer.js", "addLayer", arglist=[overlay_file, self.map_id, bounds, self.colorbar, self.side])
         self.map.runjs("/js/image_layer.js", "setOpacity", arglist=[self.map_id, self.opacity, self.side])
         if self.side != "b":
             self.map.runjs("/js/image_layer.js", "setLegendPosition", arglist=[self.map_id, self.legend_position, self.side])
@@ -110,97 +122,4 @@ class ImageLayer(Layer):
 
             clrbar_dict = "./overlays/" + legend_file
         return clrbar_dict
-    
-    # def set_data(self,
-    #              data,
-    #              image_file=None,
-    #              xlim=None,
-    #              ylim=None):
-        
-    #     fname = os.path.join(self.map.server_path, "overlays", self.file_name)
-
-    #     self.data = data
-
-        # id_string = self.id
-
-        # dataset = rasterio.open(image_file)
-
-        # src_crs = 'EPSG:4326'
-        # dst_crs = 'EPSG:3857'
-
-        # with rasterio.open(image_file) as src:
-        #     transform, width, height = calculate_default_transform(
-        #         src.crs, dst_crs, src.width, src.height, *src.bounds)
-        #     kwargs = src.meta.copy()
-        #     kwargs.update({
-        #         'crs': dst_crs,
-        #         'transform': transform,
-        #         'width': width,
-        #         'height': height
-        #     })
-        #     bnds = src.bounds
-
-        #     mem_file = MemoryFile()
-        #     with mem_file.open(**kwargs) as dst:
-        #         for i in range(1, src.count + 1):
-        #             reproject(
-        #                 source=rasterio.band(src, i),
-        #                 destination=rasterio.band(dst, i),
-        #                 src_transform=src.transform,
-        #                 src_crs=src.crs,
-        #                 dst_transform=transform,
-        #                 dst_crs=dst_crs,
-        #                 resampling=Resampling.nearest)
-
-        #         # band1 = dst.read(1)
-
-        # new_bounds = transform_bounds(dst_crs, src_crs,
-        #                               dst.bounds[0],
-        #                               dst.bounds[1],
-        #                               dst.bounds[2],
-        #                               dst.bounds[3])
-        # isn = np.where(band1 < 0.001)
-        # band1[isn] = np.nan
-
-        # band1 = np.flipud(band1)
-        # cminimum = np.nanmin(band1)
-        # cmaximum = np.nanmax(band1)
-
-        # norm = matplotlib.colors.Normalize(vmin=cminimum, vmax=cmaximum)
-        # vnorm = norm(band1)
-
-        # cmap = cm.get_cmap(colormap)
-        # im = Image.fromarray(np.uint8(cmap(vnorm) * 255))
-
-        # shutil.copy(image_file, os.path.join(self.map.server_path, "overlays", self.file_name))
-
-        # js_string = "import('/js/main.js').then(module => {module.removeLayer('" + self.map_id + "')});"
-        # self.map.view.page().runJavaScript(js_string)
-
-        # try:
-        #     xlim, ylim = self.make_overlay()
-        #     if xlim is None:
-        #         return
-        # except:
-        #     print("Something went wrong with map overlay : " + self.map_id)
-        #     return
-        # bounds = [[xlim[0], xlim[1]], [ylim[0], ylim[1]]]
-        # bounds_string = "[[" + str(bounds[0][0]) + "," + str(bounds[0][1]) + "],[" + str(bounds[1][0]) + "," + str(bounds[1][1]) + "]]"
-        # overlay_file = "./overlays/" + self.file_name
-        # js_string = "import('/js/image_layer.js').then(module => {module.addLayer('" + overlay_file + "','" + self.map_id + "'," + bounds_string + ","")});"
-        # self.map.view.page().runJavaScript(js_string)
-
-
-#         overlay_file = "./overlays/" + "main.background_topography.png"
-
-#         # Bounds
-#         bounds = [[xlim[0], xlim[1]], [ylim[0], ylim[1]]]
-#         bounds_string = "[[" + str(bounds[0][0]) + "," + str(bounds[0][1]) + "],[" + str(bounds[1][0]) + "," + str(bounds[1][1]) + "]]"
-
-# #        overlay_file = ""
-
-#         js_string = "import('/js/image_layer.js').then(module => {module.addLayer('" + overlay_file + "','" + self.map_id + "'," + bounds_string + ","")});"
-#         self.map.view.page().runJavaScript(js_string)
-
-# #        self.update()
 

--- a/src/guitares/map/mapbox/server/css/mapbox.css
+++ b/src/guitares/map/mapbox/server/css/mapbox.css
@@ -44,38 +44,6 @@
   line-height: 18px;
 }
 
-
-
-/**
-* Set rules for how the choropleth
-* (information box and legend) will be displayed
-* on the page. */
-.choropleth_legend {
-  position: absolute;
-  top: 20px;
-  right: 0;
-  background: #fff;
-  margin-right: 20px;
-  font-family: Arial, sans-serif;
-  overflow: auto;
-  border-radius: 3px;
-  opacity: 0.9;
-  padding: 10px;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
-  line-height: 18px;
-  margin-bottom: 40px;
-}
-
-.choropleth_legend i {
-  width: 20px;
-  height: 15px;
-  float: left;
-  margin-right: 8px;
-  border-style: solid;
-  border-width: 1px;
-}
-
-
 /**
 * Set rules for how the choropleth
 * (information box and legend) will be displayed

--- a/src/guitares/map/mapbox/server/js/choropleth_layer.js
+++ b/src/guitares/map/mapbox/server/js/choropleth_layer.js
@@ -90,7 +90,6 @@ export function addLayer(
 
   var legend     = document.createElement("div");
   legend.id        = "legend" + id;
-  //legend.className = "choropleth_legend";
   legend.className = legend_position;
   var newSpan = document.createElement('span');
   newSpan.class = 'title';

--- a/src/guitares/map/mapbox/server/js/circle_layer_custom.js
+++ b/src/guitares/map/mapbox/server/js/circle_layer_custom.js
@@ -81,7 +81,6 @@ export function addLayer(
   // Legend
   var legend     = document.createElement("div");
   legend.id        = "legend" + id;
-  //legend.className = "choropleth_legend";
   legend.className = legend_position;
   var newSpan = document.createElement('span');
   newSpan.class = 'title';

--- a/src/guitares/map/mapbox/server/js/image_layer.js
+++ b/src/guitares/map/mapbox/server/js/image_layer.js
@@ -43,7 +43,6 @@ export function addLayer(id, side) {
 
   mp.setLayoutProperty(id, 'visibility', 'visible');    
   mp.setPaintProperty(id, 'raster-opacity', 0.5);
-  setLegend(mp, id, "");
 }
 
 export function updateLayer(fileName, id, bounds, colorbar, side) {

--- a/src/guitares/map/mapbox/server/js/image_layer.js
+++ b/src/guitares/map/mapbox/server/js/image_layer.js
@@ -52,7 +52,7 @@ export function updateLayer(fileName, id, bounds, colorbar, side) {
   // If the layer does not exist, add it
   if (!mp.getLayer(id)) {
     // console.log("Layer " + id + " does not exist, adding it instead of updating it");
-    mp.addLayer(id, side);
+    addLayer(id, side);
     return;
   }
 
@@ -137,7 +137,7 @@ function setLegend(mp, id, colorbar) {
     for (let i = 0; i < colorbar["contour"].length; i++) {
       let cnt = colorbar["contour"][i]
       var newI = document.createElement('i');
-      newI.setAttribute('style','background:' + cnt["color"]);
+      newI.setAttribute('style','background:' + cnt["color"] + '; display: inline-block;'); // + '; display: inline-block; width: 12px; height: 12px; margin-right: 5px;');
       legend.appendChild(newI);
       var newSpan = document.createElement('span');
       newSpan.innerHTML = cnt["text"];
@@ -157,7 +157,6 @@ function setLegend(mp, id, colorbar) {
 }
 
 export function setLegendPosition(id, position, side) {
-  var mp = getMap(side);
   var legend = document.getElementById("legend" + id);
   if (legend) {
     if (position == "bottom-left") {

--- a/src/guitares/map/mapbox/server/js/image_layer.js
+++ b/src/guitares/map/mapbox/server/js/image_layer.js
@@ -43,7 +43,7 @@ export function addLayer(id, side) {
 
   mp.setLayoutProperty(id, 'visibility', 'visible');    
   mp.setPaintProperty(id, 'raster-opacity', 0.5);
-
+  setLegend(mp, id, "");
 }
 
 export function updateLayer(fileName, id, bounds, colorbar, side) {

--- a/src/guitares/map/mapbox/server/js/image_layer.js
+++ b/src/guitares/map/mapbox/server/js/image_layer.js
@@ -8,9 +8,8 @@ function getMap(side) {
 export function addLayer(id, side) {
 
   const blankPixel =
-  "data:image/png;base64," +
-  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=";
-
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAACZgbYAAAAHElEQVQImWNgYGBgYGBgAAAABAABJzQnCgAAAABJRU5ErkJggg==";
+    
   var mp = getMap(side);
   
   // Always remove the layer first to avoid an error
@@ -53,7 +52,7 @@ export function updateLayer(fileName, id, bounds, colorbar, side) {
   // If the layer does not exist, add it
   if (!mp.getLayer(id)) {
     // console.log("Layer " + id + " does not exist, adding it instead of updating it");
-    mp.addLayer(fileName, id, bounds, colorbar, side);
+    mp.addLayer(id, side);
     return;
   }
 
@@ -63,29 +62,10 @@ export function updateLayer(fileName, id, bounds, colorbar, side) {
     return;
   }
   
-  // If the source does not exist, add it
-  if (!mp.getSource(id)) {
-    mp.addSource(id, {
-      'type': 'image',
-      'url': fileName,
-      'coordinates': [
-        [bounds[0][0], bounds[1][1]],
-        [bounds[0][1], bounds[1][1]],
-        [bounds[0][1], bounds[1][0]],
-        [bounds[0][0], bounds[1][0]]
-      ]
-    });
-  }
-
-  var source = mp.getSource(id);
-  // If the source does not have updateImage method, do not update it
-  if (typeof source.updateImage !== 'function') {
-    // console.log("Source does not have updateImage method");
-    return;
-  }
-
-  // Update the image
-  source.updateImage({
+  mp.removeLayer(id);
+  mp.removeSource(id);
+  mp.addSource(id, {
+    'type': 'image',
     'url': fileName,
     'coordinates': [
       [bounds[0][0], bounds[1][1]],
@@ -94,7 +74,15 @@ export function updateLayer(fileName, id, bounds, colorbar, side) {
       [bounds[0][0], bounds[1][0]]
     ]
   });
-
+  mp.addLayer({
+    'id': id,
+    'source': id,
+    'type': 'raster',
+    'paint': {
+      'raster-resampling': 'nearest'
+    }
+  }, 'dummy_layer');
+  mp.setLayoutProperty(id, 'visibility', 'visible');   
   if (colorbar) {
     setLegend(mp, id, colorbar);
   }

--- a/src/guitares/map/mapbox/server/js/polygon_layer_additional_attr.js
+++ b/src/guitares/map/mapbox/server/js/polygon_layer_additional_attr.js
@@ -48,7 +48,6 @@ export function addLayer(
   // Legend
   //var legend     = document.createElement("div");
   //legend.id        = "legend" + id;
-  //legend.className = "choropleth_legend";
   //legend.className = legend_position;
   //var newSpan = document.createElement('span');
   //newSpan.class = 'title';

--- a/src/guitares/map/mapbox/server/js/polygon_layer_custom.js
+++ b/src/guitares/map/mapbox/server/js/polygon_layer_custom.js
@@ -48,7 +48,6 @@ export function addLayer(
   // Legend
   var legend     = document.createElement("div");
   legend.id        = "legend" + id;
-  //legend.className = "choropleth_legend";
   legend.className = legend_position;
   var newSpan = document.createElement('span');
   newSpan.class = 'title';

--- a/src/guitares/map/maplibre/server/css/maplibre.css
+++ b/src/guitares/map/maplibre/server/css/maplibre.css
@@ -45,37 +45,6 @@
 }
 
 
-
-/**
-* Set rules for how the choropleth
-* (information box and legend) will be displayed
-* on the page. */
-.choropleth_legend {
-  position: absolute;
-  top: 20px;
-  right: 0;
-  background: #fff;
-  margin-right: 20px;
-  font-family: Arial, sans-serif;
-  overflow: auto;
-  border-radius: 3px;
-  opacity: 0.9;
-  padding: 10px;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
-  line-height: 18px;
-  margin-bottom: 40px;
-}
-
-.choropleth_legend i {
-  width: 20px;
-  height: 15px;
-  float: left;
-  margin-right: 8px;
-  border-style: solid;
-  border-width: 1px;
-}
-
-
 /**
 * Set rules for how the choropleth
 * (information box and legend) will be displayed

--- a/src/guitares/map/maplibre/server/js/choropleth_layer.js
+++ b/src/guitares/map/maplibre/server/js/choropleth_layer.js
@@ -90,7 +90,6 @@ export function addLayer(
 
   var legend     = document.createElement("div");
   legend.id        = "legend" + id;
-  //legend.className = "choropleth_legend";
   legend.className = legend_position;
   var newSpan = document.createElement('span');
   newSpan.class = 'title';

--- a/src/guitares/map/maplibre/server/js/circle_layer_custom.js
+++ b/src/guitares/map/maplibre/server/js/circle_layer_custom.js
@@ -81,7 +81,6 @@ export function addLayer(
   // Legend
   var legend     = document.createElement("div");
   legend.id        = "legend" + id;
-  //legend.className = "choropleth_legend";
   legend.className = legend_position;
   var newSpan = document.createElement('span');
   newSpan.class = 'title';

--- a/src/guitares/map/maplibre/server/js/polygon_layer_additional_attr.js
+++ b/src/guitares/map/maplibre/server/js/polygon_layer_additional_attr.js
@@ -48,7 +48,6 @@ export function addLayer(
   // Legend
   //var legend     = document.createElement("div");
   //legend.id        = "legend" + id;
-  //legend.className = "choropleth_legend";
   //legend.className = legend_position;
   //var newSpan = document.createElement('span');
   //newSpan.class = 'title';

--- a/src/guitares/map/maplibre/server/js/polygon_layer_custom.js
+++ b/src/guitares/map/maplibre/server/js/polygon_layer_custom.js
@@ -48,7 +48,6 @@ export function addLayer(
   // Legend
   var legend     = document.createElement("div");
   legend.id        = "legend" + id;
-  //legend.className = "choropleth_legend";
   legend.className = legend_position;
   var newSpan = document.createElement('span');
   newSpan.class = 'title';

--- a/src/guitares/map/raster_from_tiles_layer.py
+++ b/src/guitares/map/raster_from_tiles_layer.py
@@ -120,11 +120,10 @@ class RasterFromTilesLayer(Layer):
 
         if self.new:
             self.map.runjs("/js/image_layer.js", "addLayer", arglist=[self.map_id, self.side])
+        self.map.runjs("/js/image_layer.js", "updateLayer", arglist=[overlay_url, self.map_id, bounds, clrbar_dict, self.side])
+        if self.new:
             # Set legend position (should make this generic for all layers)
             self.map.runjs("/js/image_layer.js", "setLegendPosition", arglist=[self.map_id, self.legend_position, self.side])
-
-        self.map.runjs("/js/image_layer.js", "updateLayer", arglist=[overlay_url, self.map_id, bounds, clrbar_dict, self.side])
-
         self.map.runjs("/js/image_layer.js", "setOpacity", arglist=[self.map_id, self.opacity, self.side])
         self.new = False
 


### PR DESCRIPTION
There we some small bugs in the image layer:

- the side for the compare map was not passed correctly
- the single pixel dummy sourse for the image layer was failing for mapbox, and even when I replaced it with a larger one the update Source was not working (probably because the type of url changes? So, reverted back to the original pass of the bounds and image.
- added a check in the imageLayer class to only recreate the overlay if extents have change and layer is visible
- I did some small cleanup in the legends as well

@maartenvanormondt can you check if these changes make sense?