### PR TITLE
Replace all print statements with logging statements

### DIFF
--- a/examples/webpage/wpc.py
+++ b/examples/webpage/wpc.py
@@ -12,9 +12,7 @@ from guitares.gui import GUI
 
 class WebPageComparison:
     def __init__(self):
-        self.gui = GUI(
-            self, framework="pyside6", config_file="webpage.yml", js_messages=False
-        )
+        self.gui = GUI(self, framework="pyside6", config_file="webpage.yml")
 
 
 wpc = WebPageComparison()

--- a/src/guitares/edit_mode.py
+++ b/src/guitares/edit_mode.py
@@ -7,6 +7,7 @@ Widgets can be dragged to new positions (snapped to a 5px grid).
 Modified positions are written back to the source YAML files.
 """
 
+import logging
 import sys
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -16,6 +17,7 @@ from PySide6.QtCore import QPoint, QRect, Qt
 from PySide6.QtWidgets import QApplication, QWidget
 
 SNAP = 5  # Grid snap in pixels
+logger = logging.getLogger(__name__)
 
 
 def is_debug() -> bool:
@@ -268,7 +270,7 @@ class EditMode:
         if self.active:
             return
         self.active = True
-        print(
+        logger.info(
             "=== EDIT MODE ON (Ctrl+E exit, Ctrl+S save, Ctrl+Z undo, Ctrl+A add) ==="
         )
         self.gui.window.dialog_fade_label(
@@ -300,7 +302,7 @@ class EditMode:
                 overlay._modified = False
                 overlay.update()
                 restored += 1
-        print(f"Undo: restored {restored} widget(s)")
+        logger.info(f"Undo: restored {restored} widget(s)")
 
     def _snapshot_positions(self) -> None:
         """Store current positions and sizes of all overlaid elements."""
@@ -313,19 +315,19 @@ class EditMode:
                 el.position.width,
                 el.position.height,
             )
-        print(f"  Snapshot: {len(self._saved_positions)} widget positions saved")
+        logger.info(f"  Snapshot: {len(self._saved_positions)} widget positions saved")
 
     def deactivate(self) -> None:
         """Exit edit mode — remove all overlays."""
         if not self.active:
             return
         self.active = False
-        print("=== EDIT MODE OFF ===")
+        logger.info("=== EDIT MODE OFF ===")
 
         # Check for unsaved changes
         modified = [o for o in self.overlays if o._modified]
         if modified:
-            print(f"  {len(modified)} widget(s) were moved. Ctrl+S to save.")
+            logger.info(f"  {len(modified)} widget(s) were moved. Ctrl+S to save.")
 
         for overlay in self.overlays:
             overlay.hide()
@@ -339,7 +341,7 @@ class EditMode:
 
         modified = [o for o in self.overlays if o._modified]
         if not modified:
-            print("No changes to save.")
+            logger.info("No changes to save.")
             return
 
         # Group modifications by source YAML file
@@ -349,21 +351,21 @@ class EditMode:
             if source:
                 by_file.setdefault(source, []).append(overlay)
             else:
-                print(
+                logger.info(
                     f"  Warning: no source YAML for {overlay.element.style} — skipping"
                 )
 
         for yml_path, overlays in by_file.items():
             try:
                 _update_yaml_positions(yml_path, overlays)
-                print(f"  Saved {len(overlays)} change(s) to {yml_path}")
+                logger.info(f"  Saved {len(overlays)} change(s) to {yml_path}")
                 for o in overlays:
                     o._modified = False
                     # Update original text so next save matches the new text
                     if isinstance(o.element.text, str):
                         o._original_text = o.element.text
             except Exception as e:
-                print(f"  Error saving {yml_path}: {e}")
+                logger.info(f"  Error saving {yml_path}: {e}")
 
         # Re-snapshot so undo reverts to the last saved state
         self._snapshot_positions()
@@ -413,7 +415,7 @@ class EditMode:
     def add_element(self) -> None:
         """Prompt for element properties, then let user click to place it."""
         if not self.active:
-            print("Enter edit mode first (Ctrl+E).")
+            logger.info("Enter edit mode first (Ctrl+E).")
             return
 
         gui = self.gui
@@ -565,7 +567,7 @@ class EditMode:
         }
 
         # Enter placement mode
-        print("Click in the GUI to place the element (Esc to cancel)...")
+        logger.info("Click in the GUI to place the element (Esc to cancel)...")
         QApplication.setOverrideCursor(Qt.CrossCursor)
 
         # Make overlays transparent to mouse events during placement
@@ -611,7 +613,7 @@ class _ClickPlacementFilter(QtCore.QObject):
         # Restore overlay mouse interaction
         for o in self.edit_mode.overlays:
             o.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents, False)
-        print("Add element cancelled.")
+        logger.info("Add element cancelled.")
 
     def _finish(self, global_pos: QPoint) -> None:
         """Place the element at the clicked position."""
@@ -626,7 +628,7 @@ class _ClickPlacementFilter(QtCore.QObject):
         parent, parent_elements = _find_guitares_parent(window, global_pos)
 
         if parent is None:
-            print("Could not determine parent container.")
+            logger.info("Could not determine parent container.")
             self._restore_overlays()
             return
 
@@ -709,7 +711,7 @@ class _ClickPlacementFilter(QtCore.QObject):
             )
 
         style = cfg["style"]
-        print(f"Added {style} at ({yaml_x}, {yaml_y}) in {var_group}")
+        logger.info(f"Added {style} at ({yaml_x}, {yaml_y}) in {var_group}")
 
 
 def _find_guitares_parent(window: Any, global_pos: QPoint) -> Tuple[Any, list]:

--- a/src/guitares/element.py
+++ b/src/guitares/element.py
@@ -1,9 +1,12 @@
 """GUI element tree: parsing YAML definitions into widget objects with layout and dependencies."""
 
 import importlib
+import logging
 from typing import Any, List, Optional, Tuple, Type
 
 from guitares.dependencies import Dependency, DependencyCheck
+
+logger = logging.getLogger(__name__)
 
 
 class Position:
@@ -202,7 +205,7 @@ class Element:
                 try:
                     self.module = importlib.import_module(dct["module"])
                 except Exception:
-                    print(f"Error! Could not import module {dct['module']}")
+                    logger.error(f"Error! Could not import module {dct['module']}")
 
         if "method" in dct:
             self.method = dct["method"]
@@ -237,7 +240,9 @@ class Element:
                                     f"Error! Could not find method {self.method} in module {self.module.__name__}"
                                 )
                 except Exception as e:
-                    print(e)
+                    logger.exception(
+                        f"Error while setting callback for method {self.method} in module {self.module.__name__}: {e}"
+                    )
         if self.variable_group in self.gui.variables:
             if self.variable in self.gui.variables[self.variable_group]:
                 self.type = type(
@@ -474,10 +479,9 @@ class Element:
                         if tab_dct["module"]:
                             tab.module = importlib.import_module(tab_dct["module"])
                     except Exception as e:
-                        print(
-                            f"Error! Module {tab_dct['module']} could not be imported!"
+                        logger.exception(
+                            f"Module {tab_dct['module']} could not be imported! Error: {e}"
                         )
-                        print(e)
 
                 tab.dependencies = []
                 if "dependency" in tab_dct:
@@ -631,7 +635,7 @@ class Element:
             self.widget = mod.WebPage(self)
 
         else:
-            print(f"Element style {self.style} not recognized!")
+            logger.error(f"Element style {self.style} not recognized!")
 
         # And set the visibility
         if self.style != "radiobuttongroup":  # Cannot set radiobutton group to visible

--- a/src/guitares/gui.py
+++ b/src/guitares/gui.py
@@ -10,6 +10,7 @@ import sys
 os.environ["QT_LOGGING_RULES"] = (
     "qt.webchannel.warning=false;qt.webengine.qwebchannel=false"
 )
+import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -18,6 +19,8 @@ import yaml
 
 from guitares.server import start_server
 from guitares.window import Window
+
+logger = logging.getLogger(__name__)
 
 
 class GUI:
@@ -45,8 +48,6 @@ class GUI:
         HTTP server port, by default 3000.
     server_nodejs : bool, optional
         Use a Node.js server instead of the built-in Python server.
-    js_messages : bool, optional
-        Enable JavaScript message passing, by default ``True``.
     copy_map_server_folder : bool, optional
         Copy the map engine server folder to *server_path*, by default ``True``.
     icon_path : str or None, optional
@@ -69,7 +70,6 @@ class GUI:
         server_path: Optional[str] = None,
         server_port: int = 3000,
         server_nodejs: bool = False,
-        js_messages: bool = True,
         copy_map_server_folder: bool = True,
         icon_path: Optional[str] = None,
         map_engine: str = "maplibre",
@@ -90,7 +90,6 @@ class GUI:
         self.server_path: Optional[str] = server_path
         self.server_port: int = server_port
         self.server_nodejs: bool = server_nodejs
-        self.js_messages: bool = js_messages
         self.popup_window: Dict[str, Any] = {}
         self.popup_data: Dict[str, Any] = {}
         self.resize_factor: float = 1.0
@@ -130,7 +129,7 @@ class GUI:
 
         if server_path:
             # Need to run http server (e.g. for MapBox or MapLibre)
-            print("Starting http server ...")
+            logger.info("Starting http server ...")
             # Run http server in separate thread
             # Use daemon=True to make sure the server stops after the application is finished
             if copy_map_server_folder:
@@ -228,7 +227,7 @@ class GUI:
         self.edit_mode = EditMode(self)
         if is_debug() and self.framework == "pyside6":
             self.edit_mode.install(self.window.window_widget)
-            print(
+            logger.info(
                 "Edit Mode  |  Ctrl+E toggle  |  Ctrl+A add  |  Ctrl+Z undo  |  Ctrl+S save"
             )
 
@@ -275,12 +274,12 @@ class GUI:
             # There is no variable for the element
             return None
         if group not in self.variables:
-            print(
+            logger.error(
                 f"Error! Cannot get variable! GUI variable group '{group}' not defined!"
             )
             return None
         elif name not in self.variables[group]:
-            print(
+            logger.error(
                 f"Error! Cannot get variable! GUI variable '{name}' not defined in group '{group}'!"
             )
             return None
@@ -297,12 +296,12 @@ class GUI:
             Variable name to delete.
         """
         if group not in self.variables:
-            print(
+            logger.error(
                 f"Error! Cannot delete variable! GUI variable group '{group}' not defined!"
             )
             return None
         elif name not in self.variables[group]:
-            print(
+            logger.error(
                 f"Error! Cannot delete variable! GUI variable '{name}' not defined in group '{group}'!"
             )
             return None
@@ -317,7 +316,7 @@ class GUI:
             Variable group name to delete.
         """
         if group not in self.variables:
-            print(
+            logger.error(
                 f"Error! Cannot delete group! GUI variable group '{group}' not defined!"
             )
             return

--- a/src/guitares/log.py
+++ b/src/guitares/log.py
@@ -1,0 +1,16 @@
+import logging
+
+root_logger = logging.getLogger("guitares")
+
+
+def init_logging():
+    """Initialize logging for guitares."""
+    logging.basicConfig(
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        level=logging.INFO,
+    )
+
+
+def set_log_level(level):
+    """Set the log level for all guitares loggers."""
+    root_logger.setLevel(level)

--- a/src/guitares/map/cyclone_track_layer.py
+++ b/src/guitares/map/cyclone_track_layer.py
@@ -46,7 +46,7 @@ class CycloneTrackLayer(Layer):
             if len(data) == 0:
                 return
         else:
-            print("Data is not a GeoDataFrame")
+            logger.error("Data is not a GeoDataFrame")
             return
 
         # We need to make a copy, because we will add columns for icon_url and hover_html

--- a/src/guitares/map/draw_layer.py
+++ b/src/guitares/map/draw_layer.py
@@ -4,6 +4,7 @@ Supports polygon, polyline, and rectangle shapes with per-feature
 selection, modification, and deletion callbacks.
 """
 
+import logging
 import math
 import random
 import string
@@ -18,6 +19,8 @@ from shapely.geometry import Polygon
 from shapely.ops import transform
 
 from .layer import Layer
+
+logger = logging.getLogger(__name__)
 
 
 class DrawLayer(Layer):
@@ -326,7 +329,7 @@ class DrawLayer(Layer):
             if indx:
                 feature_index = indx[0]
         if feature_index is None:
-            print("Could not find feature ...")
+            logger.error("Could not find feature ...")
         return feature_index
 
     def get_feature_id(self, feature_index: int) -> Optional[str]:

--- a/src/guitares/map/layer.py
+++ b/src/guitares/map/layer.py
@@ -4,9 +4,12 @@ Provides the ``Layer`` class that all specialized layer types inherit from,
 along with helper functions for traversing the layer hierarchy.
 """
 
+import logging
 from typing import Any, Dict, List, Optional
 
 import matplotlib.colors as mcolors
+
+logger = logging.getLogger(__name__)
 
 
 class Layer:
@@ -330,7 +333,7 @@ class Layer:
 
         else:
             if self.type != "container":
-                print(f"Error! Can not add layer to layer of type: {self.type}")
+                logger.error(f"Error! Can not add layer to layer of type: {self.type}")
                 return None
 
             if (
@@ -406,7 +409,7 @@ class Layer:
             #    self.layer[layer_id] = RasterTileLayer(self.map, layer_id, map_id, **kwargs)
 
             else:
-                print(f"Error! Layer type {self.type} not recognized!")
+                logger.error(f"Layer type {self.type} not recognized!")
                 return None
 
             self.layer[layer_id].type = type

--- a/src/guitares/map/maplibre/update_js_libs.py
+++ b/src/guitares/map/maplibre/update_js_libs.py
@@ -14,9 +14,12 @@ maplibre_compare.html to reference the new filenames.
 """
 
 import json
+import logging
 import os
 import re
 import urllib.request
+
+logger = logging.getLogger(__name__)
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -29,11 +32,11 @@ CSS_DIR = r"c:\work\projects\delftdashboard\dev_claude\maplibre\server\css"
 
 def download(url, dest):
     """Download a URL to a local file."""
-    print(f"  Downloading {url}")
-    print(f"  -> {os.path.basename(dest)}")
+    logger.info(f"  Downloading {url}")
+    logger.info(f"  -> {os.path.basename(dest)}")
     urllib.request.urlretrieve(url, dest)
     size_kb = os.path.getsize(dest) / 1024
-    print(f"  ({size_kb:.0f} KB)")
+    logger.info(f"  ({size_kb:.0f} KB)")
 
 
 def get_latest_github_release(owner, repo):
@@ -55,9 +58,9 @@ def get_latest_npm_version(package):
 
 def update_maplibre():
     """Download the latest MapLibre GL JS."""
-    print("\n=== MapLibre GL JS ===")
+    logger.info("\n=== MapLibre GL JS ===")
     version = get_latest_npm_version("maplibre-gl")
-    print(f"Latest version: {version}")
+    logger.info(f"Latest version: {version}")
 
     # JS bundle
     js_url = f"https://unpkg.com/maplibre-gl@{version}/dist/maplibre-gl.js"
@@ -74,9 +77,9 @@ def update_maplibre():
 
 def update_turf():
     """Download the latest Turf.js."""
-    print("\n=== Turf.js ===")
+    logger.info("\n=== Turf.js ===")
     version = get_latest_npm_version("@turf/turf")
-    print(f"Latest version: {version}")
+    logger.info(f"Latest version: {version}")
 
     js_url = f"https://unpkg.com/@turf/turf@{version}/turf.min.js"
     js_dest = os.path.join(JS_DIR, f"turf-v{version.split('.')[0]}.js")
@@ -87,9 +90,9 @@ def update_turf():
 
 def update_mapbox_draw():
     """Download the latest MapBox GL Draw (original Mapbox version)."""
-    print("\n=== MapBox GL Draw (original) ===")
+    logger.info("\n=== MapBox GL Draw (original) ===")
     version = get_latest_npm_version("@mapbox/mapbox-gl-draw")
-    print(f"Latest version: {version}")
+    logger.info(f"Latest version: {version}")
 
     js_url = (
         f"https://unpkg.com/@mapbox/mapbox-gl-draw@{version}/dist/mapbox-gl-draw.js"
@@ -108,9 +111,9 @@ def update_mapbox_draw():
 
 def update_maplibre_draw():
     """Download the latest maplibre-gl-draw (MapLibre-native fork)."""
-    print("\n=== MapLibre GL Draw (MapLibre fork) ===")
+    logger.info("\n=== MapLibre GL Draw (MapLibre fork) ===")
     version = get_latest_npm_version("maplibre-gl-draw")
-    print(f"Latest version: {version}")
+    logger.info(f"Latest version: {version}")
 
     js_url = f"https://unpkg.com/maplibre-gl-draw@{version}/dist/mapbox-gl-draw.js"
     js_dest = os.path.join(JS_DIR, f"maplibre-gl-draw-v{version}.js")
@@ -169,9 +172,9 @@ def update_html_references(maplibre_version, turf_version, draw_version):
         if content != original:
             with open(html_file, "w") as f:
                 f.write(content)
-            print(f"  Updated {os.path.basename(html_file)}")
+            logger.info((f"  Updated {os.path.basename(html_file)}")
         else:
-            print(f"  No changes in {os.path.basename(html_file)}")
+            logger.info((f"  No changes in {os.path.basename(html_file)}")
 
 
 if __name__ == "__main__":
@@ -188,9 +191,9 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    print("Updating JavaScript libraries for Guitares MapLibre server")
-    print(f"JS directory: {JS_DIR}")
-    print(f"CSS directory: {CSS_DIR}")
+    logger.info("Updating JavaScript libraries for Guitares MapLibre server")
+    logger.info(f"JS directory: {JS_DIR}")
+    logger.info(f"CSS directory: {CSS_DIR}")
 
     maplibre_ver = update_maplibre()
     turf_ver = update_turf()
@@ -205,26 +208,26 @@ if __name__ == "__main__":
     # Update HTML refs using whichever draw lib was downloaded
     # Default: use mapbox draw refs (maplibre-gl-draw uses the same filename pattern)
     html_draw_ver = draw_ver or maplibre_draw_ver
-    print("\n=== Updating HTML references ===")
+    logger.info("\n=== Updating HTML references ===")
     update_html_references(maplibre_ver, turf_ver, html_draw_ver)
 
-    print("\n=== Summary ===")
-    print(f"MapLibre GL JS: {maplibre_ver}")
-    print(f"Turf.js: {turf_ver}")
+    logger.info("\n=== Summary ===")
+    logger.info(f"MapLibre GL JS: {maplibre_ver}")
+    logger.info(f"Turf.js: {turf_ver}")
     if draw_ver:
-        print(f"MapBox GL Draw (original): {draw_ver}")
+        logger.info(f"MapBox GL Draw (original): {draw_ver}")
     if maplibre_draw_ver:
-        print(f"MapLibre GL Draw (fork): {maplibre_draw_ver}")
-    print()
-    print("To switch between draw libraries, update the <script> tag in index.html:")
+        logger.info(f"MapLibre GL Draw (fork): {maplibre_draw_ver}")
+    logger.info("")
+    logger.info("To switch between draw libraries, update the <script> tag in index.html:")
     if draw_ver:
-        print(f'  Mapbox:   <script src="/js/mapbox-gl-draw-v{draw_ver}.js"></script>')
+        logger.info(f'  Mapbox:   <script src="/js/mapbox-gl-draw-v{draw_ver}.js"></script>')
     if maplibre_draw_ver:
-        print(
+        logger.info(
             f'  MapLibre: <script src="/js/maplibre-gl-draw-v{maplibre_draw_ver}.js"></script>'
         )
-    print()
-    print("NOTE: maplibre-gl-compare.js and mapbox_gl_draw_scale_rotate_mode.js")
-    print("are custom source files — NOT updated by this script.")
-    print()
-    print("Delete old version files after verifying everything works.")
+    logger.info("")
+    logger.info("NOTE: maplibre-gl-compare.js and mapbox_gl_draw_scale_rotate_mode.js")
+    logger.info("are custom source files — NOT updated by this script.")
+    logger.info("")
+    logger.info("Delete old version files after verifying everything works.")

--- a/src/guitares/map/maplibre/update_js_libs.py
+++ b/src/guitares/map/maplibre/update_js_libs.py
@@ -172,9 +172,9 @@ def update_html_references(maplibre_version, turf_version, draw_version):
         if content != original:
             with open(html_file, "w") as f:
                 f.write(content)
-            logger.info((f"  Updated {os.path.basename(html_file)}")
+            logger.info(f"  Updated {os.path.basename(html_file)}")
         else:
-            logger.info((f"  No changes in {os.path.basename(html_file)}")
+            logger.info(f"  No changes in {os.path.basename(html_file)}")
 
 
 if __name__ == "__main__":
@@ -219,9 +219,13 @@ if __name__ == "__main__":
     if maplibre_draw_ver:
         logger.info(f"MapLibre GL Draw (fork): {maplibre_draw_ver}")
     logger.info("")
-    logger.info("To switch between draw libraries, update the <script> tag in index.html:")
+    logger.info(
+        "To switch between draw libraries, update the <script> tag in index.html:"
+    )
     if draw_ver:
-        logger.info(f'  Mapbox:   <script src="/js/mapbox-gl-draw-v{draw_ver}.js"></script>')
+        logger.info(
+            f'  Mapbox:   <script src="/js/mapbox-gl-draw-v{draw_ver}.js"></script>'
+        )
     if maplibre_draw_ver:
         logger.info(
             f'  MapLibre: <script src="/js/maplibre-gl-draw-v{maplibre_draw_ver}.js"></script>'

--- a/src/guitares/menu.py
+++ b/src/guitares/menu.py
@@ -1,9 +1,12 @@
 """Menu bar items: parsing YAML menu definitions into framework-specific menu actions."""
 
 import importlib
+import logging
 from typing import Any, List, Optional
 
 from guitares.dependencies import Dependency, DependencyCheck
+
+logger = logging.getLogger(__name__)
 
 
 class Text:
@@ -71,8 +74,8 @@ class Menu:
             if isinstance(dct["module"], str):
                 try:
                     self.module = importlib.import_module(dct["module"])
-                except Exception:
-                    print(f"Error! Could not import module {dct['module']}")
+                except Exception as e:
+                    logger.error(f"Error! Could not import module {dct['module']}: {e}")
         if "method" in dct:
             self.method = dct["method"]
             # Check if self.method is a string or a method
@@ -81,7 +84,9 @@ class Menu:
                     if hasattr(self.module, self.method):
                         self.callback = getattr(self.module, self.method)
                     else:
-                        print(f"Error! Could not find method {self.method}")
+                        logger.error(
+                            f"Error! Could not find method {self.method} in module {self.module.__name__}"
+                        )
             else:
                 # It's already a method
                 self.callback = self.method

--- a/src/guitares/pyqt5/checkbox.py
+++ b/src/guitares/pyqt5/checkbox.py
@@ -1,8 +1,11 @@
 """PyQt5 checkbox widget bound to a GUI variable."""
 
+import logging
 from typing import Any
 
 from PyQt5.QtWidgets import QCheckBox
+
+logger = logging.getLogger(__name__)
 
 
 class CheckBox(QCheckBox):
@@ -84,8 +87,7 @@ class CheckBox(QCheckBox):
             # Update GUI
             self.element.window.update()
         except Exception as e:
-            print("Error in CheckBox callback")
-            print(e)
+            logger.exception(f"Error in CheckBox callback: {e}")
 
     def set_geometry(self) -> None:
         """Set widget position and size, adjusting width to fit text."""

--- a/src/guitares/pyqt5/listbox.py
+++ b/src/guitares/pyqt5/listbox.py
@@ -1,10 +1,13 @@
 """PyQt5 list box widget with single and multi-selection support."""
 
+import logging
 import traceback
 from typing import Any
 
 from PyQt5 import QtCore
 from PyQt5.QtWidgets import QLabel, QListWidget
+
+logger = logging.getLogger(__name__)
 
 
 class ListBox(QListWidget):
@@ -123,7 +126,7 @@ class ListBox(QListWidget):
                             valstr = str(val)
                         else:
                             valstr = val
-                        print(
+                        logger.error(
                             f"Error in listbox: variable {self.element.variable} ({valstr}) not found in list!"
                         )
                 else:

--- a/src/guitares/pyqt5/mapbox.py
+++ b/src/guitares/pyqt5/mapbox.py
@@ -1,6 +1,7 @@
 """PyQt5 Mapbox GL JS map widget with WebChannel communication."""
 
 import json
+import logging
 import os
 from typing import Any, Optional
 
@@ -11,6 +12,8 @@ from PyQt5 import QtCore, QtWebChannel, QtWebEngineWidgets, QtWidgets
 
 from guitares.map.layer import Layer, find_layer_by_id, list_layers
 
+logger = logging.getLogger(__name__)
+
 
 class WebEnginePage(QtWebEngineWidgets.QWebEnginePage):
     """Custom web engine page that optionally prints JS console messages.
@@ -19,15 +22,10 @@ class WebEnginePage(QtWebEngineWidgets.QWebEnginePage):
     ----------
     view : QtWebEngineWidgets.QWebEngineView
         The parent web engine view.
-    print_messages : bool
-        Whether to print JavaScript console messages to stdout.
     """
 
-    def __init__(
-        self, view: QtWebEngineWidgets.QWebEngineView, print_messages: bool
-    ) -> None:
+    def __init__(self, view: QtWebEngineWidgets.QWebEngineView) -> None:
         super().__init__(view)
-        self.print_messages = print_messages
 
     def javaScriptConsoleMessage(
         self, level: int, message: str, lineNumber: int, sourceID: str
@@ -45,8 +43,9 @@ class WebEnginePage(QtWebEngineWidgets.QWebEnginePage):
         sourceID : str
             The source file identifier.
         """
-        if self.print_messages:
-            print("javaScriptConsoleMessage: ", level, message, lineNumber, sourceID)
+        logger.info(
+            f"javaScriptConsoleMessage: {level} {message} {lineNumber} {sourceID}"
+        )
 
 
 class MapBox(QtWidgets.QWidget):
@@ -102,7 +101,7 @@ class MapBox(QtWidgets.QWidget):
 
         self.set_geometry()
 
-        page = WebEnginePage(view, self.gui.js_messages)
+        page = WebEnginePage(view)
         view.setPage(page)
 
         view.page().setWebChannel(channel)
@@ -554,7 +553,7 @@ class MapBox(QtWidgets.QWidget):
             self.layer[layer_id] = Layer(self, layer_id, layer_id)
             self.layer[layer_id].map_id = layer_id
         else:
-            print(f"Layer {layer_id} already exists.")
+            logger.warning(f"Layer {layer_id} already exists.")
         return self.layer[layer_id]
 
     def list_layers(self) -> list[Any]:

--- a/src/guitares/pyqt5/mapbox_compare.py
+++ b/src/guitares/pyqt5/mapbox_compare.py
@@ -1,6 +1,7 @@
 """PyQt5 Mapbox GL JS comparison map widget with side-by-side views."""
 
 import json
+import logging
 import os
 from typing import Any, Optional
 
@@ -8,6 +9,8 @@ from geopandas import GeoDataFrame
 from PyQt5 import QtCore, QtWebChannel, QtWebEngineWidgets, QtWidgets
 
 from guitares.map.layer import Layer, list_layers
+
+logger = logging.getLogger(__name__)
 
 
 class WebEnginePage(QtWebEngineWidgets.QWebEnginePage):
@@ -17,15 +20,10 @@ class WebEnginePage(QtWebEngineWidgets.QWebEnginePage):
     ----------
     view : QtWebEngineWidgets.QWebEngineView
         The parent web engine view.
-    print_messages : bool
-        Whether to print JavaScript console messages to stdout.
     """
 
-    def __init__(
-        self, view: QtWebEngineWidgets.QWebEngineView, print_messages: bool
-    ) -> None:
+    def __init__(self, view: QtWebEngineWidgets.QWebEngineView) -> None:
         super().__init__(view)
-        self.print_messages = print_messages
 
     def javaScriptConsoleMessage(
         self, level: int, message: str, lineNumber: int, sourceID: str
@@ -43,8 +41,9 @@ class WebEnginePage(QtWebEngineWidgets.QWebEnginePage):
         sourceID : str
             The source file identifier.
         """
-        if self.print_messages:
-            print("javaScriptConsoleMessage: ", level, message, lineNumber, sourceID)
+        logger.info(
+            f"javaScriptConsoleMessage: {level} {message} {lineNumber} {sourceID}"
+        )
 
 
 class MapBoxCompare(QtWidgets.QWidget):
@@ -93,7 +92,7 @@ class MapBoxCompare(QtWidgets.QWidget):
 
         self.set_geometry()
 
-        page = WebEnginePage(view, self.gui.js_messages)
+        page = WebEnginePage(view)
         view.setPage(page)
         view.page().setWebChannel(channel)
 
@@ -116,7 +115,7 @@ class MapBoxCompare(QtWidgets.QWidget):
 
     def reload(self) -> None:
         """Reload the comparison map page."""
-        print("Reloading ...")
+        logger.info("Reloading ...")
         self.view.page().setWebChannel(self.channel)
         self.channel.registerObject("MapBoxCompare", self)
         self.view.load(QtCore.QUrl(self.url))
@@ -259,7 +258,7 @@ class MapBoxCompare(QtWidgets.QWidget):
             self.layer[layer_id] = Layer(self, layer_id, layer_id)
             self.layer[layer_id].map_id = layer_id
         else:
-            print(f"Layer {layer_id} already exists.")
+            logger.warning(f"Layer {layer_id} already exists.")
         return self.layer[layer_id]
 
     def list_layers(self) -> list[Any]:

--- a/src/guitares/pyqt5/maplibre.py
+++ b/src/guitares/pyqt5/maplibre.py
@@ -1,8 +1,8 @@
 """PyQt5 MapLibre GL JS map widget with WebChannel communication."""
 
 import json
+import logging
 import os
-import sys
 from typing import Any, Optional
 
 import requests
@@ -13,6 +13,8 @@ from PyQt5 import QtCore, QtWebChannel, QtWebEngineWidgets
 
 from guitares.map.layer import Layer, find_layer_by_id, list_layers
 
+logger = logging.getLogger(__name__)
+
 
 class WebEnginePage(QtWebEngineWidgets.QWebEnginePage):
     """Custom web engine page that optionally prints JS console messages.
@@ -21,15 +23,10 @@ class WebEnginePage(QtWebEngineWidgets.QWebEnginePage):
     ----------
     view : QtWebEngineWidgets.QWebEngineView
         The parent web engine view.
-    print_messages : bool
-        Whether to print JavaScript console messages to stdout.
     """
 
-    def __init__(
-        self, view: QtWebEngineWidgets.QWebEngineView, print_messages: bool
-    ) -> None:
+    def __init__(self, view: QtWebEngineWidgets.QWebEngineView) -> None:
         super().__init__(view)
-        self.print_messages = print_messages
 
     def javaScriptConsoleMessage(
         self, level: int, message: str, lineNumber: int, sourceID: str
@@ -47,9 +44,7 @@ class WebEnginePage(QtWebEngineWidgets.QWebEnginePage):
         sourceID : str
             The source file identifier.
         """
-        if self.print_messages:
-            print(f"[JS] {message} (line {lineNumber}, source: {sourceID})")
-            sys.stdout.flush()
+        logger.info(f"[JS] {message} (line {lineNumber}, source: {sourceID})")
 
     def javaScriptAlert(self, security_origin: Any, msg: str) -> None:
         """Suppress JavaScript alert dialogs.
@@ -133,11 +128,11 @@ class MapLibre(QtCore.QObject):
         try:
             requests.get("http://www.google.com", timeout=5)
         except requests.ConnectionError:
-            print("No internet connection available.")
+            logger.warning("No internet connection available.")
             map_style = "none"
             offline = True
         else:
-            print("Internet connection available.")
+            logger.info("Internet connection available.")
             map_style = element.map_style
             offline = False
 
@@ -189,7 +184,7 @@ class MapLibre(QtCore.QObject):
         self.server_path = self.gui.server_path
 
         self.view = QtWebEngineWidgets.QWebEngineView(element.parent.widget)
-        self.view.setPage(WebEnginePage(self.view, self.gui.js_messages))
+        self.view.setPage(WebEnginePage(self.view))
 
         self.channel = QtWebChannel.QWebChannel()
         self.channel.registerObject("MapLibre", self)
@@ -198,7 +193,7 @@ class MapLibre(QtCore.QObject):
         self.set_geometry()
         self.view.loadFinished.connect(self.load_finished)
 
-        print("Loading map ...")
+        logger.info("Loading map ...")
         self.view.setUrl(QtCore.QUrl(self.url))
 
     def load_finished(self, message: bool) -> None:
@@ -640,7 +635,7 @@ class MapLibre(QtCore.QObject):
             self.layer[layer_id] = Layer(self, layer_id, layer_id)
             self.layer[layer_id].map_id = layer_id
         else:
-            print(f"Layer {layer_id} already exists.")
+            logger.warning(f"Layer {layer_id} already exists.")
         return self.layer[layer_id]
 
     def list_layers(self) -> list[Any]:

--- a/src/guitares/pyqt5/webpage.py
+++ b/src/guitares/pyqt5/webpage.py
@@ -1,8 +1,11 @@
 """PyQt5 embedded web page widget using QWebEngineView."""
 
+import logging
 from typing import Any
 
 from PyQt5 import QtCore, QtWebEngineWidgets, QtWidgets
+
+logger = logging.getLogger(__name__)
 
 
 class WebEnginePage(QtWebEngineWidgets.QWebEnginePage):
@@ -12,15 +15,10 @@ class WebEnginePage(QtWebEngineWidgets.QWebEnginePage):
     ----------
     view : QtWebEngineWidgets.QWebEngineView
         The parent web engine view.
-    print_messages : bool
-        Whether to print JavaScript console messages to stdout.
     """
 
-    def __init__(
-        self, view: QtWebEngineWidgets.QWebEngineView, print_messages: bool
-    ) -> None:
+    def __init__(self, view: QtWebEngineWidgets.QWebEngineView) -> None:
         super().__init__(view)
-        self.print_messages = print_messages
 
     def javaScriptConsoleMessage(
         self, level: int, message: str, lineNumber: int, sourceID: str
@@ -38,8 +36,9 @@ class WebEnginePage(QtWebEngineWidgets.QWebEnginePage):
         sourceID : str
             The source file identifier.
         """
-        if self.print_messages:
-            print("javaScriptConsoleMessage: ", level, message, lineNumber, sourceID)
+        logger.info(
+            f"javaScriptConsoleMessage: {level}, {message}, {lineNumber}, {sourceID}"
+        )
 
 
 class WebPage(QtWidgets.QWidget):
@@ -60,7 +59,7 @@ class WebPage(QtWidgets.QWidget):
 
         self.set_geometry()
 
-        page = WebEnginePage(view, element.gui.js_messages)
+        page = WebEnginePage(view)
         view.setPage(page)
 
         if isinstance(self.element.url, str):

--- a/src/guitares/pyside6/checkbox.py
+++ b/src/guitares/pyside6/checkbox.py
@@ -1,8 +1,11 @@
 """PySide6 checkbox widget wrapper for Guitares GUI elements."""
 
+import logging
 from typing import Any
 
 from PySide6.QtWidgets import QCheckBox
+
+logger = logging.getLogger(__name__)
 
 
 class CheckBox(QCheckBox):
@@ -85,8 +88,7 @@ class CheckBox(QCheckBox):
             # Update GUI
             self.element.window.update()
         except Exception as e:
-            print("Error in CheckBox callback")
-            print(e)
+            logger.exception(f"Error in CheckBox callback: {e}")
 
     def set_geometry(self) -> None:
         """Position and size the checkbox based on the element descriptor."""

--- a/src/guitares/pyside6/listbox.py
+++ b/src/guitares/pyside6/listbox.py
@@ -1,10 +1,13 @@
 """PySide6 list box widget wrapper for Guitares GUI elements."""
 
+import logging
 import traceback
 from typing import Any, List, Union
 
 from PySide6 import QtCore
 from PySide6.QtWidgets import QLabel, QListWidget
+
+logger = logging.getLogger(__name__)
 
 
 class ListBox(QListWidget):
@@ -132,7 +135,7 @@ class ListBox(QListWidget):
                             valstr = str(val)
                         else:
                             valstr = val
-                        print(
+                        logger.error(
                             f"Error in listbox: variable {self.element.variable} ({valstr}) not found in list!"
                         )
                 else:

--- a/src/guitares/pyside6/mapbox.py
+++ b/src/guitares/pyside6/mapbox.py
@@ -1,6 +1,7 @@
 """PySide6 Mapbox GL JS map widget with WebChannel bridge for Guitares."""
 
 import json
+import logging
 import os
 from typing import Any, Callable, Dict, List, Optional
 
@@ -11,6 +12,8 @@ from pyproj import CRS, Transformer
 from PySide6 import QtCore, QtWebChannel, QtWebEngineCore, QtWebEngineWidgets, QtWidgets
 
 from guitares.map.layer import Layer, find_layer_by_id, list_layers
+
+logger = logging.getLogger(__name__)
 
 
 def map_styles() -> List[Dict[str, str]]:
@@ -39,15 +42,10 @@ class WebEnginePage(QtWebEngineCore.QWebEnginePage):
     ----------
     view : QtWebEngineWidgets.QWebEngineView
         The parent web view.
-    print_messages : bool
-        Whether to print JS console messages to stdout.
     """
 
-    def __init__(
-        self, view: QtWebEngineWidgets.QWebEngineView, print_messages: bool
-    ) -> None:
+    def __init__(self, view: QtWebEngineWidgets.QWebEngineView) -> None:
         super().__init__(view)
-        self.print_messages = print_messages
 
     def javaScriptConsoleMessage(
         self, level: int, message: str, lineNumber: int, sourceID: str
@@ -65,8 +63,7 @@ class WebEnginePage(QtWebEngineCore.QWebEnginePage):
         sourceID : str
             The source file identifier.
         """
-        if self.print_messages:
-            print("javaScriptConsoleMessage: ", level, message, lineNumber, sourceID)
+        logger.info("javaScriptConsoleMessage: ", level, message, lineNumber, sourceID)
 
 
 class MapBox(QtWidgets.QWidget):
@@ -101,11 +98,11 @@ class MapBox(QtWidgets.QWidget):
         try:
             requests.get("http://www.google.com", timeout=5)
         except requests.ConnectionError:
-            print("No internet connection available.")
+            logger.warning("No internet connection available.")
             map_style = "none"
             offline = True
         else:
-            print("Internet connection available.")
+            logger.info("Internet connection available.")
             map_style = element.map_style
             offline = False
 
@@ -142,7 +139,7 @@ class MapBox(QtWidgets.QWidget):
         )  # this is necessary because otherwise an invisible widget sits over the top left hand side of the screen and block the menu
 
         self.view = QtWebEngineWidgets.QWebEngineView(element.parent.widget)
-        self.view.setPage(WebEnginePage(self.view, self.gui.js_messages))
+        self.view.setPage(WebEnginePage(self.view))
         self.view.page().settings().setAttribute(
             QtWebEngineCore.QWebEngineSettings.WebAttribute.WebGLEnabled, True
         )
@@ -156,7 +153,7 @@ class MapBox(QtWidgets.QWidget):
 
         self.set_geometry()
         self.view.loadFinished.connect(self.load_finished)
-        print(f"Setting url to {self.url}")
+        logger.info(f"Setting url to {self.url}")
         self.view.setUrl(QtCore.QUrl(self.url))
 
     def load_finished(self, message: bool) -> None:
@@ -618,7 +615,7 @@ class MapBox(QtWidgets.QWidget):
             self.layer[layer_id] = Layer(self, layer_id, layer_id)
             self.layer[layer_id].map_id = layer_id
         else:
-            print(f"Layer {layer_id} already exists.")
+            logger.info(f"Layer {layer_id} already exists.")
         return self.layer[layer_id]
 
     def list_layers(self) -> List[Layer]:

--- a/src/guitares/pyside6/mapbox_compare.py
+++ b/src/guitares/pyside6/mapbox_compare.py
@@ -1,6 +1,7 @@
 """PySide6 Mapbox GL JS compare (side-by-side) map widget for Guitares."""
 
 import json
+import logging
 import os
 from typing import Any, Callable, Dict, List, Optional
 
@@ -8,6 +9,8 @@ from geopandas import GeoDataFrame
 from PySide6 import QtCore, QtWebChannel, QtWebEngineCore, QtWebEngineWidgets, QtWidgets
 
 from guitares.map.layer import Layer, list_layers
+
+logger = logging.getLogger(__name__)
 
 
 class WebEnginePage(QtWebEngineCore.QWebEnginePage):
@@ -17,15 +20,10 @@ class WebEnginePage(QtWebEngineCore.QWebEnginePage):
     ----------
     view : QtWebEngineWidgets.QWebEngineView
         The parent web view.
-    print_messages : bool
-        Whether to print JS console messages to stdout.
     """
 
-    def __init__(
-        self, view: QtWebEngineWidgets.QWebEngineView, print_messages: bool
-    ) -> None:
+    def __init__(self, view: QtWebEngineWidgets.QWebEngineView) -> None:
         super().__init__(view)
-        self.print_messages = print_messages
 
     def javaScriptConsoleMessage(
         self, level: int, message: str, lineNumber: int, sourceID: str
@@ -43,8 +41,9 @@ class WebEnginePage(QtWebEngineCore.QWebEnginePage):
         sourceID : str
             The source file identifier.
         """
-        if self.print_messages:
-            print("javaScriptConsoleMessage: ", level, message, lineNumber, sourceID)
+        logger.info(
+            f"javaScriptConsoleMessage: {level}, {message}, {lineNumber}, {sourceID}"
+        )
 
 
 class MapBoxCompare(QtWidgets.QWidget):
@@ -112,13 +111,13 @@ class MapBoxCompare(QtWidgets.QWidget):
 
         self.set_geometry()
 
-        page = WebEnginePage(view, self.gui.js_messages)
+        page = WebEnginePage(view)
         view.setPage(page)
         view.page().setWebChannel(channel)
 
         channel.registerObject("MapBoxCompare", self)
 
-        print(f"URL: {url}")
+        logger.info(f"URL: {url}")
 
         view.load(QtCore.QUrl(url))
 
@@ -137,7 +136,7 @@ class MapBoxCompare(QtWidgets.QWidget):
 
     def reload(self) -> None:
         """Reload the compare page and re-register the WebChannel."""
-        print("Reloading ...")
+        logger.info("Reloading ...")
         self.view.page().setWebChannel(self.channel)
         self.channel.registerObject("MapBoxCompare", self)
         self.view.load(QtCore.QUrl(self.url))
@@ -281,7 +280,7 @@ class MapBoxCompare(QtWidgets.QWidget):
             self.layer[layer_id] = Layer(self, layer_id, layer_id)
             self.layer[layer_id].map_id = layer_id
         else:
-            print(f"Layer {layer_id} already exists.")
+            logger.warning(f"Layer {layer_id} already exists.")
         return self.layer[layer_id]
 
     def list_layers(self) -> List[Layer]:

--- a/src/guitares/pyside6/maplibre.py
+++ b/src/guitares/pyside6/maplibre.py
@@ -1,8 +1,8 @@
 """PySide6 MapLibre GL JS map widget with WebChannel bridge for Guitares."""
 
 import json
+import logging
 import os
-import sys
 from collections import deque
 from typing import Any, Callable, Deque, Dict, List, Optional
 
@@ -14,6 +14,8 @@ from PySide6 import QtCore, QtWebChannel, QtWebEngineCore, QtWebEngineWidgets
 
 from guitares.map.layer import Layer, find_layer_by_id, list_layers
 
+logger = logging.getLogger(__name__)
+
 
 class WebEnginePage(QtWebEngineCore.QWebEnginePage):
     """Custom web engine page with JS console output and suppressed JS dialogs.
@@ -22,15 +24,10 @@ class WebEnginePage(QtWebEngineCore.QWebEnginePage):
     ----------
     view : QtWebEngineWidgets.QWebEngineView
         The parent web view.
-    print_messages : bool
-        Whether to print JS console messages to stdout.
     """
 
-    def __init__(
-        self, view: QtWebEngineWidgets.QWebEngineView, print_messages: bool
-    ) -> None:
+    def __init__(self, view: QtWebEngineWidgets.QWebEngineView) -> None:
         super().__init__(view)
-        self.print_messages = print_messages
 
     def javaScriptConsoleMessage(
         self, level: int, message: str, lineNumber: int, sourceID: str
@@ -48,12 +45,10 @@ class WebEnginePage(QtWebEngineCore.QWebEnginePage):
         sourceID : str
             The source file identifier.
         """
-        if self.print_messages:
-            # Suppress noisy DOMException errors from MapLibre internals
-            if "DOMException" in message:
-                return
-            print(f"[JS] {message} (line {lineNumber}, source: {sourceID})")
-            sys.stdout.flush()  # Ensures it appears even if buffering is active
+        # Suppress noisy DOMException errors from MapLibre internals
+        if "DOMException" in message:
+            return
+        logger.info(f"[JS] {message} (line {lineNumber}, source: {sourceID})")
 
     def javaScriptAlert(self, security_origin: Any, msg: str) -> None:
         """Suppress JavaScript alert() dialogs.
@@ -141,11 +136,11 @@ class MapLibre(QtCore.QObject):
         try:
             requests.get("http://www.google.com", timeout=5)
         except requests.ConnectionError:
-            print("No internet connection available.")
+            logger.warning("No internet connection available.")
             map_style = "none"
             offline = True
         else:
-            print("Internet connection available.")
+            logger.info("Internet connection available.")
             map_style = element.map_style
             offline = False
 
@@ -222,7 +217,7 @@ class MapLibre(QtCore.QObject):
         self.server_path: str = self.gui.server_path
 
         self.view = QtWebEngineWidgets.QWebEngineView(element.parent.widget)
-        self.view.setPage(WebEnginePage(self.view, self.gui.js_messages))
+        self.view.setPage(WebEnginePage(self.view))
         self.view.page().settings().setAttribute(
             QtWebEngineCore.QWebEngineSettings.LocalContentCanAccessRemoteUrls, True
         )
@@ -234,7 +229,7 @@ class MapLibre(QtCore.QObject):
         self.set_geometry()
         self.view.loadFinished.connect(self.load_finished)
 
-        print("Loading map ...")
+        logger.info("Loading map ...")
         self.view.setUrl(QtCore.QUrl(self.url))
 
     def load_finished(self, message: bool) -> None:
@@ -711,7 +706,7 @@ class MapLibre(QtCore.QObject):
             self.layer[layer_id] = Layer(self, layer_id, layer_id)
             self.layer[layer_id].map_id = layer_id
         else:
-            print(f"Layer {layer_id} already exists.")
+            logger.warning(f"Layer {layer_id} already exists.")
         return self.layer[layer_id]
 
     def list_layers(self) -> List[Layer]:

--- a/src/guitares/pyside6/maplibre_compare.py
+++ b/src/guitares/pyside6/maplibre_compare.py
@@ -1,8 +1,8 @@
 """PySide6 MapLibre GL JS compare (side-by-side) map widget for Guitares."""
 
 import json
+import logging
 import os
-import sys
 from collections import deque
 from typing import Any, Callable, Deque, Dict, List, Optional
 
@@ -14,6 +14,8 @@ from PySide6 import QtCore, QtWebChannel, QtWebEngineCore, QtWebEngineWidgets
 
 from guitares.map.layer import Layer, find_layer_by_id, list_layers
 
+logger = logging.getLogger(__name__)
+
 
 class WebEnginePage(QtWebEngineCore.QWebEnginePage):
     """Custom web engine page with JS console output and suppressed JS dialogs.
@@ -22,15 +24,10 @@ class WebEnginePage(QtWebEngineCore.QWebEnginePage):
     ----------
     view : QtWebEngineWidgets.QWebEngineView
         The parent web view.
-    print_messages : bool
-        Whether to print JS console messages to stdout.
     """
 
-    def __init__(
-        self, view: QtWebEngineWidgets.QWebEngineView, print_messages: bool
-    ) -> None:
+    def __init__(self, view: QtWebEngineWidgets.QWebEngineView) -> None:
         super().__init__(view)
-        self.print_messages = print_messages
 
     def javaScriptConsoleMessage(
         self, level: int, message: str, lineNumber: int, sourceID: str
@@ -48,12 +45,10 @@ class WebEnginePage(QtWebEngineCore.QWebEnginePage):
         sourceID : str
             The source file identifier.
         """
-        if self.print_messages:
-            # Suppress noisy DOMException errors from MapLibre internals
-            if "DOMException" in message:
-                return
-            print(f"[JS] {message} (line {lineNumber}, source: {sourceID})")
-            sys.stdout.flush()  # Ensures it appears even if buffering is active
+        # Suppress noisy DOMException errors from MapLibre internals
+        if "DOMException" in message:
+            return
+        logger.info(f"[JS] {message} (line {lineNumber}, source: {sourceID})")
 
     def javaScriptAlert(self, security_origin: Any, msg: str) -> None:
         """Suppress JavaScript alert() dialogs.
@@ -139,11 +134,11 @@ class MapLibreCompare(QtCore.QObject):
         try:
             requests.get("http://www.google.com", timeout=5)
         except requests.ConnectionError:
-            print("No internet connection available.")
+            logger.warning("No internet connection available.")
             map_style = "none"
             offline = True
         else:
-            print("Internet connection available.")
+            logger.info("Internet connection available.")
             map_style = element.map_style
             offline = False
 
@@ -208,7 +203,7 @@ class MapLibreCompare(QtCore.QObject):
         self.server_path: str = self.gui.server_path
 
         self.view = QtWebEngineWidgets.QWebEngineView(element.parent.widget)
-        self.view.setPage(WebEnginePage(self.view, self.gui.js_messages))
+        self.view.setPage(WebEnginePage(self.view))
         self.view.page().settings().setAttribute(
             QtWebEngineCore.QWebEngineSettings.WebAttribute.WebGLEnabled, True
         )
@@ -223,7 +218,7 @@ class MapLibreCompare(QtCore.QObject):
         self.set_geometry()
         self.view.loadFinished.connect(self.load_finished)
 
-        print("Loading compare map ...")
+        logger.info("Loading compare map ...")
         self.view.setUrl(QtCore.QUrl(f"{self.url}/maplibre_compare.html"))
 
     def load_finished(self, message: bool) -> None:
@@ -240,7 +235,7 @@ class MapLibreCompare(QtCore.QObject):
 
     def ping(self) -> None:
         """Send a ping to JavaScript to verify the WebChannel is working."""
-        # print("Ping!")
+        # logger.info("Ping!")
         self.runjs("/js/compare.js", "ping", arglist=["ping"])
 
     @QtCore.Slot(str)
@@ -253,7 +248,7 @@ class MapLibreCompare(QtCore.QObject):
             The pong message.
         """
         self.timer_ping.stop()
-        # print("Pong received! Adding map compare ...")
+        # logger.info("Pong received! Adding map compare ...")
         # Add map
         self.runjs("/js/compare.js", "addMap", arglist=[])
 
@@ -690,7 +685,7 @@ class MapLibreCompare(QtCore.QObject):
             self.layer[layer_id] = Layer(self, layer_id, layer_id)
             self.layer[layer_id].map_id = layer_id
         else:
-            print(f"Layer {layer_id} already exists.")
+            logger.warning(f"Layer {layer_id} already exists.")
         return self.layer[layer_id]
 
     def list_layers(self) -> List[Layer]:

--- a/src/guitares/pyside6/webpage.py
+++ b/src/guitares/pyside6/webpage.py
@@ -12,15 +12,10 @@ class WebEnginePage(QtWebEngineCore.QWebEnginePage):
     ----------
     view : QtWebEngineWidgets.QWebEngineView
         The parent web view.
-    print_messages : bool
-        Whether to print JavaScript console messages to stdout.
     """
 
-    def __init__(
-        self, view: QtWebEngineWidgets.QWebEngineView, print_messages: bool
-    ) -> None:
+    def __init__(self, view: QtWebEngineWidgets.QWebEngineView) -> None:
         super().__init__(view)
-        self.print_messages = print_messages
 
     def javaScriptConsoleMessage(
         self, level: int, message: str, lineNumber: int, sourceID: str
@@ -60,7 +55,7 @@ class WebPage(QtWidgets.QWidget):
 
         self.set_geometry()
 
-        page = WebEnginePage(view, element.gui.js_messages)
+        page = WebEnginePage(view)
         view.setPage(page)
 
         if isinstance(self.element.url, str):

--- a/src/guitares/server.py
+++ b/src/guitares/server.py
@@ -1,5 +1,6 @@
 """HTTP server utilities for serving map tile files to the Qt web view."""
 
+import logging
 import os
 import threading
 import time
@@ -8,6 +9,8 @@ import urllib.request
 from http.server import HTTPServer as BaseHTTPServer
 from http.server import SimpleHTTPRequestHandler
 from typing import Any, Optional, Tuple, Type
+
+logger = logging.getLogger(__name__)
 
 
 # Custom Exception Class
@@ -59,7 +62,7 @@ class ServerThread(threading.Thread):
             Always raised after ``serve_forever`` returns (should not happen
             under normal operation).
         """
-        print(f"Server path : {self.server_path}")
+        logger.info(f"Server path : {self.server_path}")
         httpd = HTTPServer(self.server_path, ("", self.server_port))
         httpd.serve_forever()
         name = threading.current_thread().name
@@ -148,7 +151,7 @@ def run_node_server(server_path: str, server_port: int) -> None:
     server_port : int
         Port number (currently unused by the batch script).
     """
-    print(f"Node server path : {server_path}")
+    logger.info(f"Node server path : {server_path}")
     os.chdir(server_path)
     os.system("run_node_server.bat")
 
@@ -184,10 +187,10 @@ def start_server(
                 url = f"http://localhost:{port}"
                 request = urllib.request.urlopen(url)
                 request.close()
-                print(f"Found server running at port {port} ...")
+                logger.info(f"Found server running at port {port} ...")
                 break
             except Exception:
-                print("Waiting for server ...")
+                logger.info("Waiting for server ...")
                 time.sleep(1)
         return the
     else:
@@ -199,9 +202,9 @@ def start_server(
                 url = f"http://localhost:{port}"
                 request = urllib.request.urlopen(url)
                 request.close()
-                print(f"Found server running at port {port} ...")
+                logger.info(f"Found server running at port {port} ...")
                 break
             except Exception:
-                print("Waiting for server ...")
+                logger.info("Waiting for server ...")
                 time.sleep(1)
         return the

--- a/src/guitares/window.py
+++ b/src/guitares/window.py
@@ -1,6 +1,7 @@
 """Application window: builds the main or popup window, manages elements, menus, and dialogs."""
 
 import importlib
+import logging
 import os
 import pathlib
 from typing import Any, List, Optional, Tuple
@@ -8,6 +9,8 @@ from typing import Any, List, Optional, Tuple
 from guitares.dialog import window_dialog
 from guitares.element import Element
 from guitares.menu import Menu
+
+logger = logging.getLogger(__name__)
 
 
 class MenuBar:
@@ -338,7 +341,7 @@ class Window:
                         # Set the dependencies
                         element.set_dependencies()
             except Exception as err:
-                print(err)
+                logger.exception(err)
 
     def find_element_by_id(
         self, element_id: str, elements: Optional[List[Element]] = None


### PR DESCRIPTION
Added `guitares.log` for some config functions.
Also removed `print_messages` from various classes as this can now be configured with pythons builtin logging.

By default, any call to `logger.info|debug|error` does not output anything if that logger (or any of its parents) does not have a handler.

This means that:
- It is completely up to users how much output they want and how they configure it, which is best practice in python.
- Library developer can just output everything at the correct verbosity level, and then loggers + handlers + log levels will take care of what to show to users.

`init_logging` adds a `logging,StreamHandler` that outputs to `sys.stderr`, so you should call this close to the entry point of the app.

# Default config (this adds a console handler if nothing is configured yet)
```python
import logging
from guitares.log import init_logging

init_logging() 
```

# Example Custom config
```python
import logging

# Customize formatting for all log messages by configuring this object
formatter = logging.Formatter()

#  This logger gets ALL messages from all loggers, even other packages
root_logger = logging.getLogger()

# This only gets messages from any loggers that have the name "guitares.*" 
# e.g. all loggers created with logging.getLogger(__name__) in the guitares package
logger = logging.getLogger("guitares")  
logger.setLevel(logging.INFO)

filehandler = logging.FileHandler("gui.log")
logger.addHandler(filehandler) # this outputs ONLY the guitares logs to a file, while ignoring any other loggers

console_handler = logging.StreamHandler() # outputs to the terminal
console_handler.setLevel(level)
console_handler.setFormatter(_formatter)
root_logger.addHandler(console_handler)...

gui = GUI(...)
...
```