### PR TITLE
  Fix layer hiding, choropleth hovering, and unify raster legends

### DIFF
--- a/src/guitares/map/maplibre/server/js/main.js
+++ b/src/guitares/map/maplibre/server/js/main.js
@@ -233,7 +233,7 @@ export function addMap() {
 
   window.currentCursor = '';
 
-  map.on('load', () => {
+  map.on('load', async () => {
     addDummyLayer('dummy_layer_0');
     addDummyLayer('dummy_layer_1');
     map.addControl(draw, 'top-left');
@@ -248,6 +248,24 @@ export function addMap() {
         // Silently ignore icon loading errors (e.g. DOMException from duplicate adds)
       }
     });
+    // Pre-warm the per-type layer modules before signalling map-ready. The Python
+    // side serialises layer commands via runjs (import(module).then(m => m.fn()); void 0),
+    // but the queue advances on the synchronous `void 0` return, not when the imported
+    // function actually runs. A first-time import() (e.g. line_layer.js addLayer) then
+    // resolves AFTER an already-cached import() (main.js hideLayer), reordering them and
+    // dropping e.g. a hide() issued right after a set_data() at startup. Warming the cache
+    // here makes every later import() resolve in FIFO enqueue order.
+    try {
+      await Promise.all([
+        import('./line_layer.js'), import('./circle_layer.js'),
+        import('./polygon_layer.js'), import('./marker_layer.js'),
+        import('./image_layer.js'), import('./raster_image_layer.js'),
+        import('./raster_tile_layer.js'), import('./heatmap_layer.js'),
+        import('./draw_layer.js'),
+      ]);
+    } catch (e) {
+      // Ignore — a missing optional module must not block map-ready.
+    }
     mapLoaded();
   });
 

--- a/src/guitares/map/maplibre/server/js/polygon_layer.js
+++ b/src/guitares/map/maplibre/server/js/polygon_layer.js
@@ -170,7 +170,12 @@ export function addLayer(id, data, pp, options) {
     const hoverLayerId = hasFill ? id + '.fill' : id + '.line';
     const hoverPopup = new maplibregl.Popup({ closeButton: false, closeOnClick: false });
 
-    mp.on('mouseenter', hoverLayerId, function(e) {
+    // Use 'mousemove' (not 'mouseenter'): all features share one layer, so
+    // 'mouseenter' fires only once on first entry and never again as the
+    // cursor crosses between adjacent polygons. 'mousemove' fires on every
+    // move, so the popup follows the cursor and updates per-feature.
+    mp.on('mousemove', hoverLayerId, function(e) {
+      if (!e.features || e.features.length === 0) return;
       mp.getCanvas().style.cursor = 'pointer';
       const val = e.features[0].properties[opts.hoverProperty];
       let text = opts.hoverProperty + ': ' + numberWithCommas(val);

--- a/src/guitares/map/maplibre/server/js/raster_image_layer.js
+++ b/src/guitares/map/maplibre/server/js/raster_image_layer.js
@@ -152,6 +152,12 @@ function setLegend(mp, id, colorbar, legend_position) {
     while (brs.length > 0) {
       brs[0].parentNode.removeChild(brs[0]);
     }
+    // Discrete legends wrap each row (and the title) in a <div>; remove those
+    // leftovers too so only the colorbar image remains.
+    const divs = legend.getElementsByTagName('div');
+    while (divs.length > 0) {
+      divs[0].parentNode.removeChild(divs[0]);
+    }
 
   } else {
     // Colorbar is an object with title and contour -- remove the image
@@ -175,23 +181,30 @@ function setLegend(mp, id, colorbar, legend_position) {
     legend.innerHTML = '';
     legend.classList.add("legend");
 
-    const titleSpan = document.createElement('span');
-    titleSpan.classList.add('title');
-    titleSpan.innerHTML = '<b>' + colorbar["title"] + '</b>';
-    legend.appendChild(titleSpan);
-    legend.appendChild(document.createElement("br"));
+    // Markup mirrors buildLegend() in polygon_layer.js so a flood-depth legend
+    // looks identical whether it comes from this raster (flood map) layer or a
+    // choropleth (roads) layer. They share the same title/labels/colors, so an
+    // identical DOM lets the two legends overlap exactly when both are shown.
+    if (colorbar["title"]) {
+      const titleDiv = document.createElement('div');
+      titleDiv.innerHTML = '<strong>' + colorbar["title"] + '</strong>';
+      legend.appendChild(titleDiv);
+    }
 
     for (let i = 0; i < colorbar["contour"].length; i++) {
       const cnt = colorbar["contour"][i];
+      const item = document.createElement('div');
+
       const newI = document.createElement('i');
-      newI.setAttribute('style', 'background:' + cnt["color"]);
+      newI.setAttribute('style', 'background:' + cnt["color"] + '; width:18px; height:18px; display:inline-block; margin-right:5px;');
       if (cnt["shape"] === "circle") newI.classList.add("circle");
-      legend.appendChild(newI);
+      item.appendChild(newI);
 
       const newSpan = document.createElement('span');
       newSpan.innerHTML = cnt["text"];
-      legend.appendChild(newSpan);
-      legend.appendChild(document.createElement("br"));
+      item.appendChild(newSpan);
+
+      legend.appendChild(item);
     }
     document.body.appendChild(legend);
 

--- a/src/guitares/map/raster_image_layer.py
+++ b/src/guitares/map/raster_image_layer.py
@@ -185,6 +185,24 @@ class RasterImageLayer(Layer):
         overlay_file = f"./overlays/{self.file_name}"
         legend = self._build_legend_from_options(opts)
 
+        # Continuous colorbar fallback: if the overlay object exposes a colormap
+        # and a (cmin, cmax) range but no discrete classes, build a colorbar PNG
+        # legend from those attributes. This is what lets continuous overlays
+        # (e.g. a topography/bathymetry DEM) keep a legend; discrete overlays
+        # set color_values on the layer instead and are skipped here.
+        if (
+            legend is None
+            and self.color_values is None
+            and getattr(self.data, "color_values", None) is None
+            and getattr(self.data, "cmap", None) is not None
+            and getattr(self.data, "cmin", None) is not None
+            and getattr(self.data, "cmax", None) is not None
+        ):
+            self._cmap = cm.get_cmap(self.data.cmap)
+            self._cmin = self.data.cmin
+            self._cmax = self.data.cmax
+            legend = "__plot_png__"
+
         return overlay_file, lonlim[0], lonlim[1], latlim[0], latlim[1], legend
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
### Summary
 A handful of related fixes to the MapLibre layer rendering: layers occasionally failed to hide on startup, polygon hover popups didn't follow the cursor, and raster (flood-map) legends didn't visually match choropleth legends. Also adds a continuous-colorbar legend fallback for raster overlays.

### Changes

**Fix layers not hiding at init** (`main.js`)
 Layer commands from the Python side are serialised via `runjs` as `import(module).then(m => m.fn()); void 0`, but the command queue advances on the synchronous `void 0` return — not when the imported function actually runs. A first-time `import()` (e.g. `line_layer.js addLayer`) could resolve *after* an already-cached `import()` (`main.js hideLayer`), reordering the two and dropping a `hide()` issued right after a `set_data()` at startup. We now pre-warm all per-type layer modules on `map.load` before signalling map-ready, so every later `import()` resolves in FIFO enqueue order. A missing optional module is swallowed and won't block map-ready.

  **Fix choropleth hover popups** (`polygon_layer.js`)
Switched the hover handler from `mouseenter` to `mousemove`. Since all features share a single layer, `mouseenter` fired only once on first entry and never again as the cursor crossed between adjacent polygons. `mousemove` updates the popup per-feature as the cursor moves (with an empty-features guard).

  **Unify raster and choropleth legends** (`raster_image_layer.js`)
  Reworked the discrete raster legend markup to mirror `buildLegend()` in `polygon_layer.js` — same title/label/swatch DOM structure. A flood-depth legend now looks identical whether it originates from the raster (flood map) layer or a choropleth (roads) layer, so the two overlap exactly when both are shown. Also cleans up leftover `<div>` wrappers when switching a legend back to a plain colorbar image.

  **Continuous colorbar fallback for raster overlays** (`raster_image_layer.py`)
  When an overlay exposes a colormap and `(cmin, cmax)` range but no discrete classes, we now build a colorbar PNG legend from those attributes. This lets continuous overlays (e.g. a topography/bathymetry DEM) keep a legend; discrete overlays set `color_values` and are skipped.